### PR TITLE
return errors when registration fails

### DIFF
--- a/app/models/services/cmm_registrar.rb
+++ b/app/models/services/cmm_registrar.rb
@@ -19,15 +19,15 @@ class CmmRegistrar
                                  contact_hint: @user.contact_hint)
   rescue CoverMyMeds::Error::HTTPError => e
     Rails.logger.info "Error registering the user with CMM: #{e.message}"
+    false
   end
 
   def unregister_with_cmm
     @user.update_attributes(registered_with_cmm: false)
-    begin
-      api_client.delete_credential(@user.npi)
-    rescue CoverMyMeds::Error::HTTPError => e
-      Rails.logger.info "Error unregistering with CMM: #{e.message}"
-    end
+    api_client.delete_credential(@user.npi)
+  rescue CoverMyMeds::Error::HTTPError => e
+    Rails.logger.info "Error unregistering with CMM: #{e.message}"
+    false
   end
 
   private


### PR DESCRIPTION
Only NPIs starting with '9' are allowed to register for the demo app. This catches any errors caused by registering other provider NPIs for the demo app.